### PR TITLE
Remove choosenim cache

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,12 +23,6 @@ jobs:
       nim_version: '1.2.0'
     steps:
       - uses: actions/checkout@v1
-      - name: Cache choosenim
-        id: cache-choosenim
-        uses: actions/cache@v1
-        with:
-          path: ~/.choosenim
-          key: ${{ runner.os }}-choosenim-${{ env.nim_version }}
       - name: Cache nimble
         id: cache-nimble
         uses: actions/cache@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,6 @@ jobs:
       TIMEOUT_EXIT_STATUS: 124
     steps:
       - uses: actions/checkout@v1
-      - name: Cache choosenim
-        id: cache-choosenim
-        uses: actions/cache@v1
-        with:
-          path: ~/.choosenim
-          key: ${{ runner.os }}-choosenim-${{ matrix.nim_version }}
       - name: Cache nimble
         id: cache-nimble
         uses: actions/cache@v1


### PR DESCRIPTION
Caching `choosenim` is not effectively for speed-up when Nim compiler version is not `devel --latest`.