### PR TITLE
Better usability with `@` macro

### DIFF
--- a/src/nodesnim/nodes/node.nim
+++ b/src/nodesnim/nodes/node.nim
@@ -253,6 +253,22 @@ macro expectParams(params_src: NimNode, params: static[seq[string]]): untyped =
     result.add quote do:
       var `varName` = `params_src`[`i` + 1] # + 1 since name is at the 0 index
 
+when not declared(nimIdentNormalize):
+  proc nimIdentNormalize(s: string): string =
+    ## Backported from https://github.com/nim-lang/Nim/blob/version-1-4/lib/pure/strutils.nim#L284
+    result = newString(s.len)
+    if s.len > 0:
+      result[0] = s[0]
+    var j = 1
+    for i in 1..len(s) - 1:
+      if s[i] in {'A'..'Z'}:
+        result[j] = chr(ord(s[i]) + (ord('a') - ord('A')))
+        inc j
+      elif s[i] != '_':
+        result[j] = s[i]
+        inc j
+    if j != s.len: setLen(result, j)
+
 macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
   ## It provides a convenient wrapper for the event handler.
   ##

--- a/src/nodesnim/nodes/node.nim
+++ b/src/nodesnim/nodes/node.nim
@@ -283,8 +283,7 @@ macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
   # Do style insensitive comparision
   case nimIdentNormalize(ename)
   of "onprocess", "onready", "onenter", "onexit":
-    var
-      name = event_name[0]
+    var name = event_name[0]
     event_name.expectParams(@["self"])
     result = quote do:
       `node`.`name` =
@@ -292,8 +291,7 @@ macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
           `code`
 
   of "onfocus", "onunfocus":
-    var
-      name = event_name[0]
+    var name = event_name[0]
     event_name.expectParams(@["self"])
     result = quote do:
       `node`.`name` =
@@ -301,8 +299,7 @@ macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
           `code`
 
   of "ontouch":
-    var
-      name = event_name[0]
+    var name = event_name[0]
     event_name.expectParams(@["self", "x", "y"])
 
     result = quote do:
@@ -319,8 +316,7 @@ macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
           `code`
 
   of "oninput":
-    var
-      name = event_name[0]
+    var name = event_name[0]
     event_name.expectParams(@["self", "arg"])
     result = quote do:
       `node`.`name` =
@@ -328,8 +324,7 @@ macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
           `code`
 
   of "onswitch":
-    var
-      name = event_name[0]
+    var name = event_name[0]
     event_name.expectParams(@["self", "arg"])
     result = quote do:
       `node`.`name` =
@@ -337,8 +332,7 @@ macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
           `code`
 
   of "ontoggle":
-    var
-      name = event_name[0]
+    var name = event_name[0]
     event_name.expectParams(@["self", "arg"])
     result = quote do:
       `node`.`name` =
@@ -346,8 +340,7 @@ macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
           `code`
 
   of "onchanged":
-    var
-      name = event_name[0]
+    var name = event_name[0]
     event_name.expectParams(@["self", "arg"])
     result = quote do:
       `node`.`name` =
@@ -355,8 +348,7 @@ macro `@`*(node: NodeRef, event_name, code: untyped): untyped =
           `code`
 
   of "onedit":
-    var
-      name = event_name[0]
+    var name = event_name[0]
     event_name.expectParams(@["self", "arg"])
     result = quote do:
       `node`.`name` =


### PR DESCRIPTION
This code didn't work before (it would silently fail) but now does with this PR
```nim
# It didn't check with style insensitivity so `onClick` != `on_click` in the macro
button@onClick(self, x, y):
    hello.setText($x & ", " & $y)
```
Also doesn't silently fail anymore when an invalid event is passed
```
Error: Invalid event: onCluck
```

Also provides better error messages when having invalid amount of parameters e.g.
```nim
button@onClick(self):
    # code
```
which now gives an error message at compile time
```
Error: Expected 3 parameters (self, x, y)  but got 1
```

also have a question about line 280 (in my PR), is there any valid code that can be used with the `@` macro that doesn't need parameters?
I was looking at all the blocks in the case statement and all of them seem to require the `event_name[0]` branch anyways 

p.s. loving the library, keep up the good work